### PR TITLE
Sysinternals Live - Usage Wording - Cmd Prompt

### DIFF
--- a/sysinternals/index.md
+++ b/sysinternals/index.md
@@ -21,7 +21,9 @@ The Sysinternals web site was created in 1996 by [Mark Russinovich](https://blog
 ---
 ## Sysinternals Live
 
-Sysinternals Live is a service that enables you to execute Sysinternals tools directly from the Web without hunting for and manually downloading them. Simply enter a tool's Sysinternals Live path into Windows Explorer or a command prompt as live.sysinternals.com/&lt;toolname&gt; or  \\\\live.sysinternals.com\tools\\&lt;toolname&gt;.
+Sysinternals Live is a service that enables you to execute Sysinternals tools directly from the Web without hunting for and manually downloading them.
+Simply enter a tool's Sysinternals Live path into Windows Explorer as live.sysinternals.com/&lt;toolname&gt; or \\\\live.sysinternals.com\tools\\&lt;toolname&gt;.
+Alternatively, you can command prompt with the format of \\\\live.sysinternals.com\tools\\&lt;toolname&gt;.
 
 You can view the entire Sysinternals Live tools directory in a browser at [https://live.sysinternals.com/](https://live.sysinternals.com).
 


### PR DESCRIPTION
Checked that the live.sysinternals.com/<toolname> method does not work with the command prompt - only the the \\live.sysinterrnals.com\tools\ format works with the command prompt.

Previous wording implied that the command prompt will work with both.